### PR TITLE
Add basic decision tree pipeline demo

### DIFF
--- a/basic/__init__.py
+++ b/basic/__init__.py
@@ -1,0 +1,20 @@
+"""Basic machine learning pipeline package."""
+
+from .data import load_iris_data
+from .pipeline import (  # noqa: F401
+    DatasetSplits,
+    create_dataset_splits,
+    perform_hyperparameter_search,
+    train_final_model,
+)
+from .evaluation import evaluate_model, plot_accuracy_progression  # noqa: F401
+
+__all__ = [
+    "load_iris_data",
+    "DatasetSplits",
+    "create_dataset_splits",
+    "perform_hyperparameter_search",
+    "train_final_model",
+    "evaluate_model",
+    "plot_accuracy_progression",
+]

--- a/basic/data.py
+++ b/basic/data.py
@@ -1,0 +1,25 @@
+"""Data loading utilities for the basic machine learning pipeline."""
+
+from typing import Tuple
+
+import pandas as pd
+from sklearn.datasets import load_iris
+
+
+def load_iris_data() -> Tuple[pd.DataFrame, pd.Series, list[str]]:
+    """Load the classic Iris dataset as Pandas objects.
+
+    Returns
+    -------
+    tuple[pd.DataFrame, pd.Series, list[str]]
+        Feature matrix, target vector, and the list of target names.
+    """
+
+    dataset = load_iris(as_frame=True)
+    features: pd.DataFrame = dataset.data
+    target: pd.Series = dataset.target
+    target_names: list[str] = list(dataset.target_names)
+    return features, target, target_names
+
+
+__all__ = ["load_iris_data"]

--- a/basic/demo.py
+++ b/basic/demo.py
@@ -1,0 +1,46 @@
+"""Demo script that runs the full decision tree training pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .data import load_iris_data
+from .evaluation import evaluate_model, plot_accuracy_progression
+from .pipeline import create_dataset_splits, perform_hyperparameter_search, train_final_model
+
+
+OUTPUT_DIR = Path(__file__).resolve().parent / "outputs"
+
+
+def run_demo() -> None:
+    """Execute the training pipeline and report metrics."""
+
+    features, target, _ = load_iris_data()
+    splits = create_dataset_splits(features, target)
+
+    estimator, best_params = perform_hyperparameter_search(splits)
+    print("Best hyper-parameters:")
+    for key, value in best_params.items():
+        print(f"  {key}: {value}")
+
+    tuned_metrics = evaluate_model(estimator, splits)
+    print("\nAccuracy after hyper-parameter tuning:")
+    for split_name, data in tuned_metrics.items():
+        print(f"  {split_name.capitalize()}: {data['accuracy']:.3f}")
+
+    print("\nValidation classification report:")
+    print(tuned_metrics["validation"]["classification_report"])
+
+    final_estimator = train_final_model(estimator, splits)
+    final_metrics = evaluate_model(final_estimator, splits)
+
+    print("\nFinal model accuracy (retrained on train + validation):")
+    for split_name, data in final_metrics.items():
+        print(f"  {split_name.capitalize()}: {data['accuracy']:.3f}")
+
+    chart_path = plot_accuracy_progression(tuned_metrics, OUTPUT_DIR / "accuracy_progression.png")
+    print(f"\nAccuracy chart saved to: {chart_path}")
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/basic/evaluation.py
+++ b/basic/evaluation.py
@@ -1,0 +1,74 @@
+"""Evaluation and reporting utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import matplotlib.pyplot as plt
+from sklearn.base import ClassifierMixin
+from sklearn.metrics import accuracy_score, classification_report
+
+from .pipeline import DatasetSplits
+
+
+def evaluate_model(
+    estimator: ClassifierMixin,
+    splits: DatasetSplits,
+) -> Dict[str, Dict[str, float | str]]:
+    """Compute classification metrics for train, validation, and test datasets."""
+
+    metrics: Dict[str, Dict[str, float | str]] = {}
+    for split_name, X, y in [
+        ("train", splits.X_train, splits.y_train),
+        ("validation", splits.X_val, splits.y_val),
+        ("test", splits.X_test, splits.y_test),
+    ]:
+        predictions = estimator.predict(X)
+        accuracy = accuracy_score(y, predictions)
+        report = classification_report(
+            y,
+            predictions,
+            output_dict=False,
+            zero_division=0,
+        )
+        metrics[split_name] = {
+            "accuracy": accuracy,
+            "classification_report": report,
+        }
+
+    return metrics
+
+
+def plot_accuracy_progression(
+    metrics: Dict[str, Dict[str, float | str]],
+    output_path: Path,
+) -> Path:
+    """Create a simple bar chart of accuracy across dataset splits."""
+
+    accuracies = {
+        split_name: data["accuracy"]
+        for split_name, data in metrics.items()
+        if "accuracy" in data
+    }
+    ordered_splits = ["train", "validation", "test"]
+    y_values = [accuracies.get(name, 0.0) for name in ordered_splits]
+
+    figure, axis = plt.subplots(figsize=(6, 4))
+    bars = axis.bar(ordered_splits, y_values, color=["#4c72b0", "#55a868", "#c44e52"])
+    axis.set_ylim(0, 1)
+    axis.set_ylabel("Accuracy")
+    axis.set_title("Decision Tree Accuracy Progression")
+    axis.grid(axis="y", linestyle="--", alpha=0.6)
+
+    for bar, value in zip(bars, y_values):
+        axis.text(bar.get_x() + bar.get_width() / 2, value + 0.02, f"{value:.3f}", ha="center")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    figure.tight_layout()
+    figure.savefig(output_path)
+    plt.close(figure)
+    return output_path
+
+
+__all__ = ["evaluate_model", "plot_accuracy_progression"]

--- a/basic/pipeline.py
+++ b/basic/pipeline.py
@@ -1,0 +1,109 @@
+"""Core training utilities for the decision tree pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Tuple
+
+import pandas as pd
+from sklearn.base import ClassifierMixin
+from sklearn.model_selection import GridSearchCV, train_test_split
+from sklearn.tree import DecisionTreeClassifier
+
+
+@dataclass
+class DatasetSplits:
+    """Container for train, validation, and test splits."""
+
+    X_train: pd.DataFrame
+    X_val: pd.DataFrame
+    X_test: pd.DataFrame
+    y_train: pd.Series
+    y_val: pd.Series
+    y_test: pd.Series
+
+
+SplitReturn = Tuple[pd.DataFrame, pd.Series]
+
+
+def create_dataset_splits(
+    features: pd.DataFrame,
+    target: pd.Series,
+    *,
+    test_size: float = 0.2,
+    validation_size: float = 0.2,
+    random_state: int = 42,
+) -> DatasetSplits:
+    """Create train, validation, and test splits from the dataset."""
+
+    X_temp, X_test, y_temp, y_test = train_test_split(
+        features,
+        target,
+        test_size=test_size,
+        random_state=random_state,
+        stratify=target,
+    )
+
+    validation_ratio = validation_size / (1 - test_size)
+    X_train, X_val, y_train, y_val = train_test_split(
+        X_temp,
+        y_temp,
+        test_size=validation_ratio,
+        random_state=random_state,
+        stratify=y_temp,
+    )
+
+    return DatasetSplits(
+        X_train=X_train,
+        X_val=X_val,
+        X_test=X_test,
+        y_train=y_train,
+        y_val=y_val,
+        y_test=y_test,
+    )
+
+
+def perform_hyperparameter_search(
+    splits: DatasetSplits,
+    *,
+    cv_folds: int = 5,
+    scoring: str = "accuracy",
+) -> Tuple[ClassifierMixin, Dict[str, Any]]:
+    """Run grid search cross-validation to optimise model hyper-parameters."""
+
+    param_grid: Dict[str, list[Any]] = {
+        "max_depth": [None, 2, 3, 4, 5],
+        "min_samples_split": [2, 4, 6, 8],
+        "min_samples_leaf": [1, 2, 3],
+        "criterion": ["gini", "entropy"],
+    }
+
+    search = GridSearchCV(
+        DecisionTreeClassifier(random_state=42),
+        param_grid=param_grid,
+        cv=cv_folds,
+        scoring=scoring,
+        n_jobs=-1,
+    )
+    search.fit(splits.X_train, splits.y_train)
+    return search.best_estimator_, search.best_params_
+
+
+def train_final_model(
+    estimator: ClassifierMixin,
+    splits: DatasetSplits,
+) -> ClassifierMixin:
+    """Retrain the estimator on the combined train and validation sets."""
+
+    X_combined = pd.concat([splits.X_train, splits.X_val], axis=0)
+    y_combined = pd.concat([splits.y_train, splits.y_val], axis=0)
+    estimator.fit(X_combined, y_combined)
+    return estimator
+
+
+__all__ = [
+    "DatasetSplits",
+    "create_dataset_splits",
+    "perform_hyperparameter_search",
+    "train_final_model",
+]


### PR DESCRIPTION
## Summary
- add a new `basic` package that loads the Iris dataset and prepares train/validation/test splits
- implement cross-validated hyper-parameter tuning, evaluation utilities, and accuracy charting
- provide a demo script that runs the full pipeline and saves a chart of accuracy across splits

## Testing
- python -m basic.demo *(fails: ModuleNotFoundError: No module named 'sklearn'; scikit-learn is required to run the demo)*

------
https://chatgpt.com/codex/tasks/task_b_68dbc0675fb88321a4010d445dd0198a