### PR TITLE
Add Jupyter notebook version of basic demo pipeline

### DIFF
--- a/basic/demo.ipynb
+++ b/basic/demo.ipynb
@@ -1,0 +1,95 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Basic Decision Tree Demo\n",
+    "\n",
+    "This notebook mirrors the behaviour of `basic/demo.py` while keeping the code interactive.\n",
+    "It reuses the same helper modules from the repository to load data, run the pipeline, and\n",
+    "summarise model performance.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "from basic.data import load_iris_data\n",
+    "from basic.evaluation import evaluate_model, plot_accuracy_progression\n",
+    "from basic.pipeline import (\n",
+    "    create_dataset_splits,\n",
+    "    perform_hyperparameter_search,\n",
+    "    train_final_model,\n",
+    ")\n",
+    "\n",
+    "OUTPUT_DIR = Path(\"basic\") / \"outputs\"\n",
+    "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_demo() -> None:\n",
+    "    \"\"\"Execute the training pipeline and report metrics.\"\"\"\n",
+    "\n",
+    "    features, target, _ = load_iris_data()\n",
+    "    splits = create_dataset_splits(features, target)\n",
+    "\n",
+    "    estimator, best_params = perform_hyperparameter_search(splits)\n",
+    "    print(\"Best hyper-parameters:\")\n",
+    "    for key, value in best_params.items():\n",
+    "        print(f\"  {key}: {value}\")\n",
+    "\n",
+    "    tuned_metrics = evaluate_model(estimator, splits)\n",
+    "    print(\"\\nAccuracy after hyper-parameter tuning:\")\n",
+    "    for split_name, data in tuned_metrics.items():\n",
+    "        print(f\"  {split_name.capitalize()}: {data['accuracy']:.3f}\")\n",
+    "\n",
+    "    print(\"\\nValidation classification report:\")\n",
+    "    print(tuned_metrics[\"validation\"][\"classification_report\"])\n",
+    "\n",
+    "    final_estimator = train_final_model(estimator, splits)\n",
+    "    final_metrics = evaluate_model(final_estimator, splits)\n",
+    "\n",
+    "    print(\"\\nFinal model accuracy (retrained on train + validation):\")\n",
+    "    for split_name, data in final_metrics.items():\n",
+    "        print(f\"  {split_name.capitalize()}: {data['accuracy']:.3f}\")\n",
+    "\n",
+    "    chart_path = plot_accuracy_progression(\n",
+    "        tuned_metrics, OUTPUT_DIR / \"accuracy_progression.png\"\n",
+    "    )\n",
+    "    print(f\"\\nAccuracy chart saved to: {chart_path}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_demo()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Jupyter notebook equivalent of `basic/demo.py`
- keep the notebook grounded on the existing data, evaluation, and pipeline modules

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dbd9e23bac8321a0a56112179f4943