### PR TITLE
Add AR(1) residual support and loglik helper

### DIFF
--- a/precision/precision/__init__.py
+++ b/precision/precision/__init__.py
@@ -33,6 +33,10 @@ _EXPORTS = {
     "compute_roas": ("precision.precision.roi", "compute_roas"),
     "posterior_mean": ("precision.precision.summaries", "posterior_mean"),
     "summarise_decay_rates": ("precision.precision.summaries", "summarise_decay_rates"),
+    "log_likelihood_draws_single_model": (
+        "precision.precision.summaries",
+        "log_likelihood_draws_single_model",
+    ),
     "fourier_seasonality": ("precision.precision.controls", "fourier_seasonality"),
     "holiday_flags": ("precision.precision.controls", "holiday_flags"),
     "stack_controls": ("precision.precision.controls", "stack_controls"),

--- a/precision/precision/constants.py
+++ b/precision/precision/constants.py
@@ -1,0 +1,5 @@
+# Numerical safety constants used across TF and NumPy code paths.
+
+SAT_MIN = 1e-9         # minimum saturation scale
+HALF_LIFE_MIN = 1e-6   # minimum half-life before converting to delta
+SIGMA_MIN = 1e-9       # minimum sigma guard when computing log-likelihoods

--- a/precision/precision/sampling.py
+++ b/precision/precision/sampling.py
@@ -10,6 +10,7 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 
 from .adstock import DTYPE
+from .constants import HALF_LIFE_MIN
 from .posterior import ParamSpec, TargetLogProbFn
 
 
@@ -49,6 +50,7 @@ class PosteriorSamples:
     tau0: np.ndarray | None = None
     lambda_local: np.ndarray | None = None
     s_sat: np.ndarray | None = None
+    phi: np.ndarray | None = None
     eta_channel: np.ndarray | None = None
     eta_platform: np.ndarray | None = None
     eta_tactical: np.ndarray | None = None
@@ -82,6 +84,7 @@ class PosteriorSamples:
             if self.lambda_local is None
             else _stack_last_two(self.lambda_local),
             s_sat=None if self.s_sat is None else _stack_last_two(self.s_sat),
+            phi=None if self.phi is None else _stack_last_two(self.phi),
             eta_channel=None
             if self.eta_channel is None
             else _stack_last_two(self.eta_channel),
@@ -170,7 +173,7 @@ def run_nuts(
     elif mode == "half_life":
         log_h = name_to_tensor["log_h"]
         h = np.exp(log_h)
-        delta = np.power(2.0, -1.0 / np.maximum(h, 1e-6))
+        delta = np.power(2.0, -1.0 / np.maximum(h, HALF_LIFE_MIN))
         extras = dict(half_life=h, logit_delta=None, mu_c=None, tau_c=None)
     elif mode == "hier_logit":
         logit_delta = name_to_tensor["logit_delta"]
@@ -216,6 +219,7 @@ def run_nuts(
     tau0 = name_to_tensor.get("tau0")
     lambda_local = name_to_tensor.get("lambda_local")
     s_sat = name_to_tensor.get("s_sat")
+    phi = name_to_tensor.get("phi")
 
     return PosteriorSamples(
         beta0=name_to_tensor["beta0"],
@@ -233,6 +237,7 @@ def run_nuts(
         tau0=tau0,
         lambda_local=lambda_local,
         s_sat=s_sat,
+        phi=phi,
         eta_channel=eta_channel,
         eta_platform=eta_platform,
         eta_tactical=eta_tactical,

--- a/precision/tests/test_scaling_and_loglik.py
+++ b/precision/tests/test_scaling_and_loglik.py
@@ -1,0 +1,90 @@
+import numpy as np
+
+from precision.precision.hierarchy import build_hierarchy
+from precision.precision.summaries import (
+    compute_contribution_arrays,
+    log_likelihood_draws_single_model,
+)
+from precision.precision.priors import Priors
+from precision.precision.sampling import PosteriorSamples
+
+
+def _toy_hierarchy():
+    tree = {"channelA": {"platformA": ["t1", "t2"]}}
+    levels = ["tactical", "platform", "channel"]
+    return build_hierarchy(tree, levels)
+
+
+def test_compute_contribution_arrays_scaling_semantics():
+    H = _toy_hierarchy()
+    U = np.array([[1.0, 3.0], [2.0, 6.0]], dtype=float)
+    delta = np.array([0.0, 0.0], dtype=float)
+    beta = np.array([1.0, 1.0], dtype=float)
+    contrib = compute_contribution_arrays(
+        U_raw=U,
+        delta=delta,
+        beta=beta,
+        beta_level="tactical",
+        hierarchy=H,
+        leaf_level="tactical",
+        normalize_adstock=False,
+        use_saturation=False,
+        s_sat=None,
+        tactical_rescale=np.array([0.5, 2.0], dtype=float),
+    )
+    expected_leaf = U * np.array([0.5, 2.0])[None, :]
+    assert np.allclose(contrib["tactical"], expected_leaf)
+
+
+def test_loglik_helper_shapes_iid_normal():
+    H = _toy_hierarchy()
+    T, N = 5, 2
+    y = np.zeros(T, dtype=float)
+    U = np.zeros((T, N), dtype=float)
+    Z = np.zeros((T, 0), dtype=float)
+    priors = Priors(
+        center_y=True,
+        standardize_media="none",
+        likelihood="normal",
+        residual_mode="iid",
+        beta_structure="tactical_hier",
+    )
+    draws = 3
+    chains = 1
+    beta0 = np.zeros((chains, draws), dtype=float)
+    sigma = np.ones((chains, draws), dtype=float)
+    delta = np.zeros((chains, draws, N), dtype=float)
+    beta_by_level = {"tactical": np.ones((chains, draws, N), dtype=float)}
+    samples = PosteriorSamples(
+        beta0=beta0,
+        beta_channel=np.zeros((chains, draws, 0)),
+        gamma=np.zeros((chains, draws, 0)),
+        delta=delta,
+        sigma=sigma,
+        half_life=None,
+        logit_delta=None,
+        mu_c=None,
+        tau_c=None,
+        beta_platform=None,
+        beta_tactical=beta_by_level["tactical"],
+        tau_beta=None,
+        tau0=None,
+        lambda_local=None,
+        s_sat=None,
+        phi=None,
+        eta_channel=None,
+        eta_platform=None,
+        eta_tactical=None,
+        eta_by_level={},
+        beta_by_level=beta_by_level,
+    )
+    L = log_likelihood_draws_single_model(
+        y=y,
+        U_tactical=U,
+        Z_controls=Z,
+        hierarchy=H,
+        priors=priors,
+        samples=samples,
+        normalize_adstock=True,
+    )
+    assert L.shape == (draws, T)


### PR DESCRIPTION
## Summary
- add centralized numerical safety constants and use them across posterior/summaries/sampling
- implement AR(1) residual support in the posterior builder and expose the per-draw log-likelihood helper
- memoize hierarchy mappings, adjust contribution scaling, and add regression tests for scaling/log-likelihood

## Testing
- pytest precision/tests/test_scaling_and_loglik.py
- pytest precision/tests/test_posterior.py

------
https://chatgpt.com/codex/tasks/task_b_68fd2ea6fe0c8321bd52f4bde5eb99a5